### PR TITLE
async notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+dependencies = [
+ "arc-swap",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,10 +1129,14 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1285,4 +1315,5 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tokio",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,3 +10,4 @@ anyhow = "1.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
+tokio = { version = "0.2", features = ["io-util", "macros", "process", "rt-core", "rt-threaded", "sync", "time", "uds"] }

--- a/runtime/src/guest_agent_comm.rs
+++ b/runtime/src/guest_agent_comm.rs
@@ -1,10 +1,14 @@
-use std::io::{self, prelude::*};
-use std::marker::PhantomData;
-use std::os::unix::net::UnixStream;
-use std::{thread, time};
+use std::{io, marker::PhantomData};
+use tokio::{
+    io::{split, AsyncWriteExt, ReadHalf, WriteHalf},
+    net::UnixStream,
+    spawn,
+    sync::mpsc,
+    time,
+};
 
 pub use crate::response_parser::Notification;
-use crate::response_parser::{parse_one_response, GuestAgentMessage, Response};
+use crate::response_parser::{parse_one_response, GuestAgentMessage, Response, ResponseWithId};
 
 #[repr(u8)]
 enum MsgType {
@@ -61,13 +65,10 @@ struct Message<T> {
     phantom: PhantomData<T>,
 }
 
-pub struct GuestAgent<F>
-where
-    F: FnMut(Notification) -> (),
-{
-    stream: UnixStream,
+pub struct GuestAgent {
+    stream: WriteHalf<UnixStream>,
     last_msg_id: u64,
-    notification_handler: F,
+    responses: mpsc::Receiver<ResponseWithId>,
 }
 
 trait EncodeInto {
@@ -284,30 +285,53 @@ impl<T> AsRef<Vec<u8>> for Message<T> {
 
 type RemoteCommandResult<T> = Result<T, /* exit code */ u32>;
 
-impl<F> GuestAgent<F>
-where
-    F: FnMut(Notification) -> (),
+async fn reader<F>(
+    mut stream: ReadHalf<UnixStream>,
+    mut notification_handler: F,
+    mut responses: mpsc::Sender<ResponseWithId>,
+) where
+    F: FnMut(Notification) -> () + Send + 'static,
 {
-    pub fn connected(
+    loop {
+        match parse_one_response(&mut stream)
+            .await
+            .expect("failed to parse response")
+        {
+            GuestAgentMessage::Notification(notification) => notification_handler(notification),
+            GuestAgentMessage::Response(resp) => {
+                responses.send(resp).await.expect("failed to send response");
+            }
+        }
+    }
+}
+
+impl GuestAgent {
+    pub async fn connected<F>(
         path: &str,
         timeout: u32,
         notification_handler: F,
-    ) -> io::Result<GuestAgent<F>> {
+    ) -> io::Result<GuestAgent>
+    where
+        F: FnMut(Notification) -> () + Send + 'static,
+    {
         let mut timeout_remaining = timeout;
         loop {
-            match UnixStream::connect(path) {
+            match UnixStream::connect(path).await {
                 Ok(s) => {
+                    let (stream_read, stream_write) = split(s);
+                    let (response_send, response_receive) = mpsc::channel(10);
+                    spawn(reader(stream_read, notification_handler, response_send));
                     break Ok(GuestAgent {
-                        stream: s,
+                        stream: stream_write,
                         last_msg_id: 0,
-                        notification_handler: notification_handler,
-                    })
+                        responses: response_receive,
+                    });
                 }
                 Err(err) => match err.kind() {
                     io::ErrorKind::NotFound => {
                         println!("Waiting for Guest Agent socket ...");
                         if timeout_remaining > 0 {
-                            thread::sleep(time::Duration::from_secs(1));
+                            time::delay_for(time::Duration::from_secs(1)).await;
                             timeout_remaining -= 1;
                         } else {
                             break Err(io::Error::new(
@@ -327,29 +351,19 @@ where
         self.last_msg_id
     }
 
-    fn get_one_response(&mut self) -> io::Result<GuestAgentMessage> {
-        parse_one_response(&mut self.stream)
-    }
-
-    fn get_response(&mut self, msg_id: u64) -> io::Result<Response> {
-        loop {
-            match self.get_one_response()? {
-                GuestAgentMessage::Notification(notification) => {
-                    (self.notification_handler)(notification)
-                }
-                GuestAgentMessage::Response { id, resp } => {
-                    break {
-                        if id != msg_id {
-                            return Err(io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                "Got response with different ID",
-                            ));
-                        }
-                        Ok(resp)
-                    }
-                }
-            }
+    async fn get_response(&mut self, msg_id: u64) -> io::Result<Response> {
+        let ResponseWithId { id, resp } = self
+            .responses
+            .recv()
+            .await
+            .ok_or(io::Error::new(io::ErrorKind::NotConnected, "disconnected"))?;
+        if id != msg_id {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Got response with different ID",
+            ));
         }
+        Ok(resp)
     }
 
     fn match_error<T>(resp: Response) -> io::Result<RemoteCommandResult<T>> {
@@ -362,38 +376,31 @@ where
         }
     }
 
-    fn get_ok_response(&mut self, msg_id: u64) -> io::Result<RemoteCommandResult<()>> {
-        match self.get_response(msg_id)? {
+    async fn get_ok_response(&mut self, msg_id: u64) -> io::Result<RemoteCommandResult<()>> {
+        match self.get_response(msg_id).await? {
             Response::Ok => Ok(Ok(())),
-            x => GuestAgent::<F>::match_error(x),
+            x => GuestAgent::match_error(x),
         }
     }
 
-    fn get_u64_response(&mut self, msg_id: u64) -> io::Result<RemoteCommandResult<u64>> {
-        match self.get_response(msg_id)? {
+    async fn get_u64_response(&mut self, msg_id: u64) -> io::Result<RemoteCommandResult<u64>> {
+        match self.get_response(msg_id).await? {
             Response::OkU64(val) => Ok(Ok(val)),
-            x => GuestAgent::<F>::match_error(x),
+            x => GuestAgent::match_error(x),
         }
     }
 
-    fn get_bytes_response(&mut self, msg_id: u64) -> io::Result<RemoteCommandResult<Vec<u8>>> {
-        match self.get_response(msg_id)? {
+    async fn get_bytes_response(
+        &mut self,
+        msg_id: u64,
+    ) -> io::Result<RemoteCommandResult<Vec<u8>>> {
+        match self.get_response(msg_id).await? {
             Response::OkBytes(bytes) => Ok(Ok(bytes)),
-            x => GuestAgent::<F>::match_error(x),
+            x => GuestAgent::match_error(x),
         }
     }
 
-    pub fn get_one_notification(&mut self) -> io::Result<Notification> {
-        match self.get_one_response()? {
-            GuestAgentMessage::Notification(notification) => Ok(notification),
-            GuestAgentMessage::Response { .. } => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Unexptected response",
-            )),
-        }
-    }
-
-    pub fn quit(&mut self) -> io::Result<RemoteCommandResult<()>> {
+    pub async fn quit(&mut self) -> io::Result<RemoteCommandResult<()>> {
         let mut msg = Message::default();
         let msg_id = self.get_new_msg_id();
 
@@ -401,19 +408,19 @@ where
 
         msg.append_submsg(&SubMsgQuitType::SubMsgEnd);
 
-        self.stream.write_all(msg.as_ref())?;
+        self.stream.write_all(msg.as_ref()).await?;
 
-        self.get_ok_response(msg_id)
+        self.get_ok_response(msg_id).await
     }
 
-    fn spawn_new_process(
+    async fn spawn_new_process(
         &mut self,
         bin: &str,
         argv: &[&str],
         maybe_env: Option<&[&str]>,
         uid: u32,
         gid: u32,
-        fds: &[Option<RedirectFdType>; 3],
+        fds: &[Option<RedirectFdType<'_>>; 3],
         maybe_cwd: Option<&str>,
         is_entrypoint: bool,
     ) -> io::Result<RemoteCommandResult<u64>> {
@@ -455,42 +462,44 @@ where
 
         msg.append_submsg(&SubMsgRunProcessType::SubMsgEnd);
 
-        self.stream.write_all(msg.as_ref())?;
+        self.stream.write_all(msg.as_ref()).await?;
 
-        self.get_u64_response(msg_id)
+        self.get_u64_response(msg_id).await
     }
 
-    pub fn run_process(
+    pub async fn run_process(
         &mut self,
         bin: &str,
         argv: &[&str],
         maybe_env: Option<&[&str]>,
         uid: u32,
         gid: u32,
-        fds: &[Option<RedirectFdType>; 3],
+        fds: &[Option<RedirectFdType<'_>>; 3],
         maybe_cwd: Option<&str>,
     ) -> io::Result<RemoteCommandResult<u64>> {
         self.spawn_new_process(
             bin, argv, maybe_env, uid, gid, fds, maybe_cwd, /*is_entrypoint=*/ false,
         )
+        .await
     }
 
-    pub fn run_entrypoint(
+    pub async fn run_entrypoint(
         &mut self,
         bin: &str,
         argv: &[&str],
         maybe_env: Option<&[&str]>,
         uid: u32,
         gid: u32,
-        fds: &[Option<RedirectFdType>; 3],
+        fds: &[Option<RedirectFdType<'_>>; 3],
         maybe_cwd: Option<&str>,
     ) -> io::Result<RemoteCommandResult<u64>> {
         self.spawn_new_process(
             bin, argv, maybe_env, uid, gid, fds, maybe_cwd, /*is_entrypoint=*/ true,
         )
+        .await
     }
 
-    pub fn kill(&mut self, id: u64) -> io::Result<RemoteCommandResult<()>> {
+    pub async fn kill(&mut self, id: u64) -> io::Result<RemoteCommandResult<()>> {
         let mut msg = Message::default();
         let msg_id = self.get_new_msg_id();
 
@@ -500,12 +509,12 @@ where
 
         msg.append_submsg(&SubMsgKillProcessType::SubMsgEnd);
 
-        self.stream.write_all(msg.as_ref())?;
+        self.stream.write_all(msg.as_ref()).await?;
 
-        self.get_ok_response(msg_id)
+        self.get_ok_response(msg_id).await
     }
 
-    pub fn mount(&mut self, tag: &str, path: &str) -> io::Result<RemoteCommandResult<()>> {
+    pub async fn mount(&mut self, tag: &str, path: &str) -> io::Result<RemoteCommandResult<()>> {
         let mut msg = Message::default();
         let msg_id = self.get_new_msg_id();
 
@@ -519,12 +528,12 @@ where
 
         msg.append_submsg(&SubMsgMountVolumeType::SubMsgEnd);
 
-        self.stream.write_all(msg.as_ref())?;
+        self.stream.write_all(msg.as_ref()).await?;
 
-        self.get_ok_response(msg_id)
+        self.get_ok_response(msg_id).await
     }
 
-    pub fn query_output(
+    pub async fn query_output(
         &mut self,
         id: u64,
         off: u64,
@@ -541,8 +550,8 @@ where
 
         msg.append_submsg(&SubMsgQueryOutputType::SubMsgEnd);
 
-        self.stream.write_all(msg.as_ref())?;
+        self.stream.write_all(msg.as_ref()).await?;
 
-        self.get_bytes_response(msg_id)
+        self.get_bytes_response(msg_id).await
     }
 }

--- a/runtime/src/response_parser.rs
+++ b/runtime/src/response_parser.rs
@@ -1,6 +1,8 @@
 use std::convert::TryFrom;
 use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
+#[derive(Debug)]
 pub enum Response {
     Ok,
     OkU64(u64),
@@ -42,70 +44,78 @@ pub enum Notification {
     ProcessDied { id: u64, reason: ExitReason },
 }
 
+#[derive(Debug)]
+pub struct ResponseWithId {
+    pub id: u64,
+    pub resp: Response,
+}
+
 pub enum GuestAgentMessage {
-    Response { id: u64, resp: Response },
+    Response(ResponseWithId),
     Notification(Notification),
 }
 
-fn recv_u8<T: io::Read>(stream: &mut T) -> io::Result<u8> {
+async fn recv_u8<T: AsyncRead + Unpin>(stream: &mut T) -> io::Result<u8> {
     let mut buf = [0; 1];
-    stream.read_exact(&mut buf)?;
+    stream.read_exact(&mut buf).await?;
     Ok(u8::from_le_bytes(buf))
 }
 
-fn recv_u32<T: io::Read>(stream: &mut T) -> io::Result<u32> {
+async fn recv_u32<T: AsyncRead + Unpin>(stream: &mut T) -> io::Result<u32> {
     let mut buf = [0; 4];
-    stream.read_exact(&mut buf)?;
+    stream.read_exact(&mut buf).await?;
     Ok(u32::from_le_bytes(buf))
 }
 
-fn recv_u64<T: io::Read>(stream: &mut T) -> io::Result<u64> {
+async fn recv_u64<T: AsyncRead + Unpin>(stream: &mut T) -> io::Result<u64> {
     let mut buf = [0; 8];
-    stream.read_exact(&mut buf)?;
+    stream.read_exact(&mut buf).await?;
     Ok(u64::from_le_bytes(buf))
 }
 
-fn recv_bytes<T: io::Read>(stream: &mut T) -> io::Result<Vec<u8>> {
-    let len = recv_u64(stream)?;
+async fn recv_bytes<T: AsyncRead + Unpin>(stream: &mut T) -> io::Result<Vec<u8>> {
+    let len = recv_u64(stream).await?;
     let mut buf = vec![0; len as usize];
-    stream.read_exact(buf.as_mut_slice())?;
+    stream.read_exact(buf.as_mut_slice()).await?;
     Ok(buf)
 }
 
-pub fn parse_one_response<T: io::Read>(stream: &mut T) -> io::Result<GuestAgentMessage> {
-    let id = recv_u64(stream)?;
+pub async fn parse_one_response<T: AsyncRead + Unpin>(
+    stream: &mut T,
+) -> io::Result<GuestAgentMessage> {
+    let id = recv_u64(stream).await?;
 
-    let typ = recv_u8(stream)?;
+    let typ = recv_u8(stream).await?;
     match typ {
-        0 => Ok(GuestAgentMessage::Response {
+        0 => Ok(GuestAgentMessage::Response(ResponseWithId {
             id: id,
             resp: Response::Ok,
-        }),
+        })),
         1 => {
-            let val = recv_u64(stream)?;
-            Ok(GuestAgentMessage::Response {
+            let val = recv_u64(stream).await?;
+            Ok(GuestAgentMessage::Response(ResponseWithId {
                 id: id,
                 resp: Response::OkU64(val),
-            })
+            }))
         }
         2 => {
-            let buf = recv_bytes(stream)?;
-            Ok(GuestAgentMessage::Response {
+            let buf = recv_bytes(stream).await?;
+            Ok(GuestAgentMessage::Response(ResponseWithId {
                 id: id,
                 resp: Response::OkBytes(buf),
-            })
+            }))
         }
         3 => {
-            let code = recv_u32(stream)?;
-            Ok(GuestAgentMessage::Response {
+            let code = recv_u32(stream).await?;
+            Ok(GuestAgentMessage::Response(ResponseWithId {
                 id: id,
                 resp: Response::Err(code),
-            })
+            }))
         }
         4 => {
             if id == 0 {
-                let proc_id = recv_u64(stream)?;
-                let fd = recv_u32(stream)?;
+                let proc_id = recv_u64(stream).await?;
+                let fd = recv_u32(stream).await?;
                 Ok(GuestAgentMessage::Notification(
                     Notification::OutputAvailable {
                         id: proc_id,
@@ -121,9 +131,9 @@ pub fn parse_one_response<T: io::Read>(stream: &mut T) -> io::Result<GuestAgentM
         }
         5 => {
             if id == 0 {
-                let proc_id = recv_u64(stream)?;
-                let status = recv_u8(stream)?;
-                let type_ = ExitType::try_from(recv_u8(stream)?)?;
+                let proc_id = recv_u64(stream).await?;
+                let status = recv_u8(stream).await?;
+                let type_ = ExitType::try_from(recv_u8(stream).await?)?;
                 Ok(GuestAgentMessage::Notification(Notification::ProcessDied {
                     id: proc_id,
                     reason: ExitReason {


### PR DESCRIPTION
Goal: Process notifications as they come; don't pull them with `get_one_notification()`.

Method: Spawn a thread that pulls data from socket. If a notification comes, it's passed to handler. If a response comes, it's put in a queue for main thread to receive.

Why: preparation for #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/36)
<!-- Reviewable:end -->
