### PR TITLE
[GuestAgent] Block SIGPIPE

### DIFF
--- a/init-container/src/init.c
+++ b/init-container/src/init.c
@@ -242,11 +242,18 @@ static void handle_sigchld(void) {
     }
 }
 
+static void block_signals(void) {
+    sigset_t set;
+    CHECK(sigemptyset(&set));
+    CHECK(sigaddset(&set, SIGCHLD));
+    CHECK(sigaddset(&set, SIGPIPE));
+    CHECK(sigprocmask(SIG_BLOCK, &set, NULL));
+}
+
 static void setup_sigfd(void) {
     sigset_t set;
     CHECK(sigemptyset(&set));
     CHECK(sigaddset(&set, SIGCHLD));
-    CHECK(sigprocmask(SIG_BLOCK, &set, NULL));
     g_sig_fd = CHECK(signalfd(g_sig_fd, &set, SFD_CLOEXEC));
 }
 
@@ -1286,6 +1293,7 @@ int main(void) {
 
     setup_agent_directories();
 
+    block_signals();
     setup_sigfd();
 
     main_loop();


### PR DESCRIPTION
We handle `EPIPE` where appropriate, but for that to work we need to block `SIGPIPE`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/47)
<!-- Reviewable:end -->
