### PR TITLE
Fix: pid-based socket name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "ya-runtime-vm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-runtime-vm"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
Changes hardcoded socket name `/tmp/foo` to `/tmp/ya_runtime_vm-{pid}.sock` to prevent conflicts while running multiple instances (already fixed on master)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/54)
<!-- Reviewable:end -->
