### PR TITLE
`cache=unsafe` in place of `cache=none` as qemu bug workaround

### DIFF
--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -276,7 +276,7 @@ impl Runtime {
             "virtserialport,chardev=manager_cdev,name=manager_port",
             "-drive",
             format!(
-                "file={},cache=none,readonly=on,format=raw,if=virtio",
+                "file={},cache=unsafe,readonly=on,format=raw,if=virtio",
                 deployment.task_package.display()
             )
             .as_str(),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/66)
<!-- Reviewable:end -->
