### PR TITLE
[fix] mount /proc

### DIFF
--- a/runtime/init-container/src/init.c
+++ b/runtime/init-container/src/init.c
@@ -1308,6 +1308,8 @@ int main(void) {
 
     CHECK(mount("devtmpfs", "/dev", "devtmpfs", MS_NOSUID,
                 "mode=0755,size=2M"));
+    CHECK(mount("proc", "/proc", "proc", MS_NOSUID,
+                NULL));
 
     setup_agent_directories();
 


### PR DESCRIPTION
Mount /proc fs, required by some example applications (e.g. yacat)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/70)
<!-- Reviewable:end -->
