### PR TITLE
Stable kernel URL (5.10.29)

### DIFF
--- a/runtime/init-container/Makefile
+++ b/runtime/init-container/Makefile
@@ -9,9 +9,9 @@ endif
 SRC_DIR ?= src
 TEST_DIR ?= tests
 
-KERNEL_VER = "5.10.26-0-virt"
-KERNEL_URL ?= "https://nl.alpinelinux.org/alpine/v3.13/main/x86_64/linux-virt-5.10.26-r0.apk"
-KERNEL_SHA256 ?= "50b93e671943b9fdec738783ce30ce6379688d0365435d40d94a87b2236e4e30"
+KERNEL_VER ?= 5.10.29-0-virt
+KERNEL_URL ?= https://ya-runtime.s3-eu-west-1.amazonaws.com/vm/kernel/linux-virt-5.10.29-r0.apk
+KERNEL_SHA256 ?= f3f7ca3421c5232e260b2a8a741bbf72c21881006afcf790aa3bc938e2262719
 
 UNPACKED_DIR := unpacked_kernel
 


### PR DESCRIPTION
- kernel URL in `runtime/init-container/Makefile` points to a Golem Factory-owned S3 bucket object
- bumps kernel version to 5.10.29

Resolves #85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/86)
<!-- Reviewable:end -->
