### PR TITLE
CPU brand in offer template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,13 +1876,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "8.1.2"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
+checksum = "929f54e29691d4e6a9cc558479de70db7aa3d98cd6fe7ab86d7507aa2886b9d2"
 dependencies = [
  "bitflags 1.3.2",
- "cc",
- "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3122,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "ya-runtime-vm"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "bollard-stubs",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-runtime-vm"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -31,7 +31,7 @@ crc = "1.8"
 env_logger = "0.7.1"
 futures = "0.3"
 log = "0.4.8"
-raw-cpuid = "8.1.2"
+raw-cpuid = "10.2.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 strip-ansi-escapes = "0.1.0"

--- a/runtime/conf/ya-runtime-vm.json
+++ b/runtime/conf/ya-runtime-vm.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "vm",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "supervisor-path": "exe-unit",
     "runtime-path": "ya-runtime-vm/ya-runtime-vm",
     "description": "vm runtime",

--- a/runtime/src/cpu.rs
+++ b/runtime/src/cpu.rs
@@ -20,6 +20,7 @@ impl CpuInfo {
 }
 
 pub struct CpuModel {
+    pub brand: String,
     pub vendor: String,
     pub stepping: u8,
     pub family: u16,
@@ -30,6 +31,9 @@ impl<'a> TryFrom<&'a CpuId> for CpuModel {
     type Error = anyhow::Error;
 
     fn try_from(info: &'a CpuId) -> Result<Self, Self::Error> {
+        let brand = info
+            .get_processor_brand_string()
+            .ok_or_else(|| anyhow::anyhow!("Unable to read CPU brand"))?;
         let vendor = info
             .get_vendor_info()
             .ok_or_else(|| anyhow::anyhow!("Unable to read CPU vendor info"))?;
@@ -38,6 +42,7 @@ impl<'a> TryFrom<&'a CpuId> for CpuModel {
             .ok_or_else(|| anyhow::anyhow!("Unable to read CPU features"))?;
 
         Ok(CpuModel {
+            brand: brand.as_str().to_string(),
             vendor: vendor.to_string(),
             stepping: features.stepping_id(),
             family: (features.extended_family_id() as u16) + (features.family_id() as u16),
@@ -130,16 +135,20 @@ fn cpu_features(info: &CpuId) -> anyhow::Result<Vec<String>> {
             ext_features,
             (has_fsgsbase, FSGSBASE),
             (has_tsc_adjust_msr, ADJUST_MSR),
+            (has_bmi1, BMI1),
+            (has_hle, HLE),
+            (has_avx2, AVX2),
             (has_fdp, FDP),
             (has_smep, SMEP),
+            (has_bmi2, BMI2),
             (has_rep_movsb_stosb, REP_MOVSB_STOSB),
             (has_invpcid, INVPCID),
+            (has_rtm, RTM),
             (has_rdtm, RDTM),
             (has_fpu_cs_ds_deprecated, DEPRECATE_FPU_CS_DS),
             (has_mpx, MPX),
             (has_rdta, RDTA),
             (has_rdseed, RDSEED),
-            (has_rdseet, RDSEED),
             (has_adx, ADX),
             (has_smap, SMAP),
             (has_clflushopt, CLFLUSHOPT),
@@ -154,6 +163,7 @@ fn cpu_features(info: &CpuId) -> anyhow::Result<Vec<String>> {
             (has_avx512cd, AVX512CD),
             (has_avx512bw, AVX512BW),
             (has_avx512vl, AVX512VL),
+            (has_clwb, CLWB),
             (has_prefetchwt1, PREFETCHWT1),
             (has_umip, UMIP),
             (has_pku, PKU),

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -401,6 +401,7 @@ fn offer() -> anyhow::Result<Option<serde_json::Value>> {
     Ok(Some(serde_json::json!({
         "properties": {
             "golem.inf.cpu.vendor": cpu.model.vendor,
+            "golem.inf.cpu.brand": cpu.model.brand,
             "golem.inf.cpu.model": model,
             "golem.inf.cpu.capabilities": cpu.capabilities,
             "golem.runtime.capabilities": ["vpn"]


### PR DESCRIPTION
- `raw-cpuid` version `10.2`
- new cpu extended feature checks
- bump runtime version to `0.2.11`

Resolves #87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golemfactory/ya-runtime-vm/111)
<!-- Reviewable:end -->
