### PR TITLE
Revert "Wait for all output to be processed before sending process exit notification."

### DIFF
--- a/runtime/init-container/include/process_bookkeeping.h
+++ b/runtime/init-container/include/process_bookkeeping.h
@@ -17,9 +17,6 @@ struct redir_fd_desc {
         struct {
             struct cyclic_buffer cb;
             int fds[2];
-            bool closed;
-            // needed to send notification
-            uint64_t process_desc_id;
         } buffer;
     };
 };
@@ -28,8 +25,6 @@ struct process_desc {
     uint64_t id;
     pid_t pid;
     bool is_alive;
-    int32_t ssi_status;
-    int32_t ssi_code;
     struct redir_fd_desc redirs[3];
     struct process_desc* prev;
     struct process_desc* next;


### PR DESCRIPTION
This reverts commit 6d3378f92e711ae81c3b92b2b26040e1cbab7068.

As discussed with @shadeofblue this change is reverted to support existing payloads.

Ramifications of this revert:
- requestor is not guaranteed to get all output before the task is considered finished
- memory leak can occur in the vm when some output is left in pipe/buffer without reading it