### PR TITLE
Load extra modules necessary in 6.1.x kernel

### DIFF
--- a/runtime/init-container/src/init.c
+++ b/runtime/init-container/src/init.c
@@ -1940,6 +1940,10 @@ int main(int argc, char **argv) {
     load_module("/failover.ko");
     load_module("/virtio.ko");
     load_module("/virtio_ring.ko");
+    if (access("/virtio_pci_modern_dev.ko", R_OK) == 0)
+        load_module("/virtio_pci_modern_dev.ko");
+    if (access("/virtio_pci_legacy_dev.ko", R_OK) == 0)
+        load_module("/virtio_pci_legacy_dev.ko");
     load_module("/virtio_pci.ko");
     load_module("/net_failover.ko");
     load_module("/virtio_net.ko");
@@ -1949,6 +1953,8 @@ int main(int argc, char **argv) {
     load_module("/virtio_blk.ko");
     load_module("/squashfs.ko");
     load_module("/overlay.ko");
+    if (access("/netfs.ko", R_OK) == 0)
+        load_module("/netfs.ko");
     load_module("/fscache.ko");
     load_module("/af_packet.ko");
     load_module("/ipv6.ko");


### PR DESCRIPTION
virtio_pci_modern_dev and virtio_pci_legacy_dev are dependencies of virtio_pci. netfs is a dependency of fscache and 9p. Kernel config doesn't allow building those as built-in when actual functionality is in a module, so load the extra modules manually when necessary.

Make it optional, to still work with older kernel too.