### PR TITLE
Multi-gpu support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
           VERSION=${TAGV_NAME#v}
           echo "::set-output name=tagv::${TAG_NAME}"
           echo "::set-output name=version::${VERSION}"
-      - uses: golemfactory/build-deb-action@v4
+      - uses: golemfactory/build-deb-action@v0.6
         id: deb
         with:
           debVersion: ${{ steps.version.outputs.version }}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub struct Cli {
     inet_endpoint: Option<Url>,
     /// PCI device identifier
     #[structopt(long, env = "YA_RUNTIME_VM_PCI_DEVICE")]
-    pci_device: Option<String>,
+    pci_device: Option<Vec<String>>,
     #[structopt(flatten)]
     test_config: TestConfig,
 }

--- a/runtime/src/self_test.rs
+++ b/runtime/src/self_test.rs
@@ -23,7 +23,7 @@ const FILE_TEST_IMAGE: &str = "self-test.gvmi";
 const FILE_TEST_EXECUTABLE: &str = "ya-self-test";
 
 pub(crate) async fn test(
-    pci_device_id: Option<String>,
+    pci_device_id: Option<Vec<String>>,
     test_config: TestConfig,
 ) -> Result<(), Error> {
     run_self_test(verify_status, pci_device_id, test_config).await;
@@ -38,7 +38,7 @@ pub(crate) fn verify_status(status: anyhow::Result<Value>) -> anyhow::Result<Str
 
 pub(crate) async fn run_self_test<HANDLER>(
     handle_result: HANDLER,
-    pci_device_id: Option<String>,
+    pci_device_id: Option<Vec<String>>,
     test_config: TestConfig,
 ) where
     HANDLER: Fn(anyhow::Result<Value>) -> anyhow::Result<String>,
@@ -108,7 +108,7 @@ pub(crate) async fn run_self_test<HANDLER>(
     .await;
 }
 
-fn self_test_runtime(deployment: Deployment, pci_device_id: Option<String>) -> Runtime {
+fn self_test_runtime(deployment: Deployment, pci_device_id: Option<Vec<String>>) -> Runtime {
     let runtime_data = RuntimeData {
         deployment: Some(deployment),
         pci_device_id,

--- a/runtime/src/vmrt.rs
+++ b/runtime/src/vmrt.rs
@@ -30,7 +30,7 @@ pub struct RuntimeData {
     pub inet: Option<ContainerEndpoint>,
     pub deployment: Option<Deployment>,
     pub ga: Option<Arc<Mutex<GuestAgent>>>,
-    pub pci_device_id: Option<String>,
+    pub pci_device_id: Option<Vec<String>>,
 }
 
 impl RuntimeData {
@@ -109,8 +109,10 @@ pub async fn start_vmrt(
     ]);
 
     if let Some(pci_device_id) = &data.pci_device_id {
-        cmd.arg("-device");
-        cmd.arg(format!("vfio-pci,host={}", pci_device_id).as_str());
+        for device_id in pci_device_id.iter() {
+            cmd.arg("-device");
+            cmd.arg(format!("vfio-pci,host={}", device_id).as_str());
+        }
     } else {
         cmd.arg("-vga");
         cmd.arg("none");


### PR DESCRIPTION
This is necessary for supporting multi-GPU runtimes. Implementation-wise, make "pci_device" a list, which automatically makes it allow multiple --pci-device= options. And then turn that into multiple vfio-pci options to QEMU.

Additionally, create `/dev/nvidia*` device for each card within the VM.

Some comments/questions:
- I have considered renaming `pci_device` to `pci_devices`, but IMO it isn't worth it really
- `Vec<String>` would be more natural type, but that doesn't work well with `structopt`
- `YA_RUNTIME_VM_PCI_DEVICE` env variable works only for a single device (maybe there is some syntax in `structopt` to pass multiple values, but I haven't found it); not a problem for the live-usb case